### PR TITLE
Update instructions based on recently walking through them

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ gcloud workstations configs create $LOCALLLM_WORKSTATION \
 --region=$REGION \
 --cluster=$LOCALLLM_CLUSTER \
 --machine-type=e2-standard-32 \
---container-custom-image=us-central1-docker.pkg.dev/$PROJECT_ID/$LOCALLLM_REGISTRY/$LOCALLLM_IMAGE_NAME
+--container-custom-image=us-central1-docker.pkg.dev/$PROJECT_ID/$LOCALLLM_REGISTRY/$LOCALLLM_IMAGE_NAME:latest
 ```
 
 1. Create a Cloud Workstation.

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ pip3 install openai
 pip3 install ./llm-tool/.
 ```
 
-2. Download and run a model.
+1. Download and run a model.
 
 ```shell
 llm run TheBloke/Llama-2-13B-Ensemble-v5-GGUF 8000
 ```
 
-3. Try out a query. The default query is for a haiku about cats.
+1. Try out a query. The default query is for a haiku about cats.
 
 ```shell
 python3 querylocal.py
 ```
 
-4. Interact with the Open API interface via the `/docs` extension. For the above, visit http://localhost:8000/docs. 
+1. Interact with the Open API interface via the `/docs` extension. For the above, visit http://localhost:8000/docs.
 
-## Running on [Cloud Workstation][cw]
+## Running as a [Cloud Workstation][cw]
 
 This repository includes a [Dockerfile](./Dockerfile) that can be used to create a [custom base image][cw-custom] 
 for a Cloud Workstation environment that includes the `llm` tool.
@@ -44,22 +44,23 @@ To get started, you'll need to have a [GCP Project][gcp] and have the `gcloud` C
    export PROJECT_NUM=<project-num>
    ```
    
-   2. Set other needed environment variables. You can modify the values.
+   1. Set other needed environment variables. You can modify the values.
    ```shell
    export REGION=us-central1
    export LOCALLLM_REGISTRY=localllm-registry
+   export LOCALLLM_IMAGE_NAME=localllm
    export LOCALLLM_CLUSTER=localllm-cluster
    export LOCALLLM_WORKSTATION=localllm-workstation
    export LOCALLLM_PORT=8000
    ```
 
-2. Set the default project.
+1. Set the default project.
 
 ```shell
 gcloud config set project $PROJECT_ID
 ```
 
-3. Enable needed services.
+1. Enable needed services.
 
 ```shell
 gcloud services enable \
@@ -71,7 +72,7 @@ gcloud services enable \
   artifactregistry.googleapis.com
 ```
 
-4. Create an Artifact Registry repository for docker images.
+1. Create an Artifact Registry repository for docker images.
 
 ```shell
 gcloud artifacts repositories create $LOCALLLM_REGISTRY \
@@ -79,21 +80,21 @@ gcloud artifacts repositories create $LOCALLLM_REGISTRY \
   --repository-format=docker
 ```
 
-5. Build and push the image to Artifact Registry using Cloud Build. Details are in [cloudbuild.yaml](cloudbuild.yaml).
-   The published image is `us-central1-docker.pkg.dev/$PROJECT_ID/localllm/localllm`.
+1. Build and push the image to Artifact Registry using Cloud Build. Details are in [cloudbuild.yaml](cloudbuild.yaml).
 
 ```shell
-gcloud builds submit .
+gcloud builds submit . \
+    --substitutions=_IMAGE_REGISTRY=$LOCALLLM_REGISTRY,_IMAGE_NAME=$LOCALLLM_IMAGE_NAME
 ```
 
-7. Configure a Cloud Workstation cluster.
+1. Configure a Cloud Workstation cluster.
 
 ```shell
 gcloud workstations clusters create $LOCALLLM_CLUSTER \
   --region=$REGION
 ```
 
-8. Create a Cloud Workstation configuration. We suggest using a machine type of e2-standard-32 which has 32 vCPU, 16 
+1. Create a Cloud Workstation configuration. We suggest using a machine type of e2-standard-32 which has 32 vCPU, 16
    core and 128 GB memory.
 
 ```shell
@@ -101,10 +102,10 @@ gcloud workstations configs create $LOCALLLM_WORKSTATION \
 --region=$REGION \
 --cluster=$LOCALLLM_CLUSTER \
 --machine-type=e2-standard-32 \
---container-custom-image=us-central1-docker.pkg.dev/$PROJECT_ID/localllm/localllm
+--container-custom-image=us-central1-docker.pkg.dev/$PROJECT_ID/$LOCALLLM_REGISTRY/$LOCALLLM_IMAGE_NAME
 ```
 
-9. Create a Cloud Workstation.
+1. Create a Cloud Workstation.
 
 ```shell
 gcloud workstations create $LOCALLLM_WORKSTATION \
@@ -113,7 +114,7 @@ gcloud workstations create $LOCALLLM_WORKSTATION \
 --region=$REGION
 ```
 
-10. Grant access to the default Cloud Workstation service account.
+1. Grant access to the default Cloud Workstation service account.
 
 ```shell
 gcloud artifacts repositories add-iam-policy-binding $LOCALLLM_REGISTRY \
@@ -122,7 +123,7 @@ gcloud artifacts repositories add-iam-policy-binding $LOCALLLM_REGISTRY \
   --role=roles/artifactregistry.reader
 ```
 
-11. Start the workstation.
+1. Start the workstation.
 
 ```shell
 gcloud workstations start $LOCALLLM_WORKSTATION \
@@ -131,7 +132,7 @@ gcloud workstations start $LOCALLLM_WORKSTATION \
   --region=$REGION
 ```
 
-12. Connect to the workstation using ssh. Alternatively, you can connect to the workstation
+1. Connect to the workstation using ssh. Alternatively, you can connect to the workstation
    [interactively][launch-workstation] in the browser.
 
 ```bash
@@ -141,13 +142,13 @@ gcloud workstations ssh $LOCALLLM_WORKSTATION \
   --region=$REGION
 ```
 
-13. Start serving the default model from the repo.
+1. Start serving the default model from the repo.
 
 ```shell
 llm run TheBloke/Llama-2-13B-Ensemble-v5-GGUF $LOCALLLM_PORT
 ```
 
-14. Get the hostname of the workstation using:
+1. Get the hostname of the workstation using:
 
 ```bash
 gcloud workstations describe $LOCALLLM_WORKSTATION \
@@ -156,7 +157,7 @@ gcloud workstations describe $LOCALLLM_WORKSTATION \
   --region=$REGION
 ```
 
-15. Interact with the model by visiting the live OpenAPI documentation page: `https://$LOCALLLM_PORT-$LLM_HOSTNAME/docs`.
+1. Interact with the model by visiting the live OpenAPI documentation page: `https://$LOCALLLM_PORT-$LLM_HOSTNAME/docs`.
 
 ## llm commands
 
@@ -172,13 +173,13 @@ the model with 4 bit medium quantization, or you can specify a filename explicit
 llm list
 ```
 
-2. List running models. 
+1. List running models. 
 
 ```shell
 llm ps
 ```
 
-3. Start serving models.
+1. Start serving models.
 
    1. Start serving the default model from the repo. Download if not present.
 
@@ -186,13 +187,13 @@ llm ps
    llm run TheBloke/Llama-2-13B-Ensemble-v5-GGUF 8000
    ```
 
-   2. Start serving a specific model. Download if not present.
+   1. Start serving a specific model. Download if not present.
 
    ```shell
    llm run TheBloke/Llama-2-13B-Ensemble-v5-GGUF --filename llama-2-13b-ensemble-v5.Q4_K_S.gguf 8000
    ```
 
-4. Stop serving models.
+1. Stop serving models.
 
    1. Stop serving all models from the repo.
 
@@ -200,33 +201,33 @@ llm ps
    llm kill TheBloke/Llama-2-13B-Ensemble-v5-GGUF
    ```
 
-   2. Stop serving a specific model.
+   1. Stop serving a specific model.
 
    ```shell
    llm kill TheBloke/Llama-2-13B-Ensemble-v5-GGUF --filename llama-2-13b-ensemble-v5.Q4_K_S.gguf
    ```
 
-5. Download models.
+1. Download models.
 
    1. Download the default model from the repo. 
 
    ```shell
    llm pull TheBloke/Llama-2-13B-Ensemble-v5-GGUF
    ```
-   2. Download a specific model from the repo.
+   1. Download a specific model from the repo.
 
    ```shell
    llm pull TheBloke/Llama-2-13B-Ensemble-v5-GGUF --filename llama-2-13b-ensemble-v5.Q4_K_S.gguf
    ```
 
-6. Remove models.
+1. Remove models.
 
    1. Remove all models downloaded from the repo.
 
    ```shell
    llm rm TheBloke/Llama-2-13B-Ensemble-v5-GGUF
    ```
-   2. Remove a specific model from the repo.
+   1. Remove a specific model from the repo.
 
    ```shell
    llm rm TheBloke/Llama-2-13B-Ensemble-v5-GGUF --filename llama-2-13b-ensemble-v5.Q4_K_S.gguf

--- a/README.md
+++ b/README.md
@@ -5,29 +5,12 @@ Run LLMs locally on Cloud Workstations. Uses:
 - Quantized models from 🤗
 - [llama-cpp-python's webserver][web-server]
 
-## Running locally
+In this guide:
 
-1. Install the tools.
-
-```shell
-# Install the tools
-pip3 install openai
-pip3 install ./llm-tool/.
-```
-
-1. Download and run a model.
-
-```shell
-llm run TheBloke/Llama-2-13B-Ensemble-v5-GGUF 8000
-```
-
-1. Try out a query. The default query is for a haiku about cats.
-
-```shell
-python3 querylocal.py
-```
-
-1. Interact with the Open API interface via the `/docs` extension. For the above, visit http://localhost:8000/docs.
+* [Running as a Cloud Workstation](#running-as-a-cloud-workstation)
+* [llm commands](#llm-commands)
+* [Running locally](#running-locally)
+* [LLM disclaimer](#llm-disclaimer)
 
 ## Running as a [Cloud Workstation][cw]
 
@@ -232,6 +215,30 @@ llm ps
    ```shell
    llm rm TheBloke/Llama-2-13B-Ensemble-v5-GGUF --filename llama-2-13b-ensemble-v5.Q4_K_S.gguf
    ```
+
+## Running locally
+
+1. Install the tools.
+
+```shell
+# Install the tools
+pip3 install openai
+pip3 install ./llm-tool/.
+```
+
+1. Download and run a model.
+
+```shell
+llm run TheBloke/Llama-2-13B-Ensemble-v5-GGUF 8000
+```
+
+1. Try out a query. The default query is for a haiku about cats.
+
+```shell
+python3 querylocal.py
+```
+
+1. Interact with the Open API interface via the `/docs` extension. For the above, visit http://localhost:8000/docs.
 
 ## LLM Disclaimer
 

--- a/cloudbuild-test.yaml
+++ b/cloudbuild-test.yaml
@@ -14,8 +14,9 @@
 
 substitutions:
   _GCR_LOCATION: us-central1-docker.pkg.dev
-  _IMAGE_NAME: cw/localllm
-  _IMAGE_TAG: ${COMMIT_SHA}
+  _IMAGE_REGISTRY: cw
+  _IMAGE_NAME: localllm
+  _IMAGE_TAG: ${COMMIT_SHA:-latest}
 steps:
   - name: python:3.10
     script: |
@@ -31,13 +32,13 @@ steps:
         "build",
         ".",
         "-t",
-        "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${_IMAGE_TAG}",
+        "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_REGISTRY}/${_IMAGE_NAME}:${_IMAGE_TAG}",
         "-f",
         "Dockerfile",
       ]
     dir: "."
   # Run tests on the image itself
-  - name: "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${_IMAGE_TAG}"
+  - name: "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_REGISTRY}/${_IMAGE_NAME}:${_IMAGE_TAG}"
     script: |
       set -xe
       llm pull TheBloke/Llama-2-13B-Ensemble-v5-GGUF

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,8 @@
 
 substitutions:
   _GCR_LOCATION: us-central1-docker.pkg.dev
-  _IMAGE_NAME: cw/localllm
+  _IMAGE_REGISTRY: cw
+  _IMAGE_NAME: localllm
   _IMAGE_TAG: ${COMMIT_SHA:-latest}
 steps:
   # Build and tag using commit sha
@@ -24,16 +25,16 @@ steps:
         "build",
         ".",
         "-t",
-        "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${_IMAGE_TAG}",
+        "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_REGISTRY}/${_IMAGE_NAME}:${_IMAGE_TAG}",
         "-f",
         "Dockerfile",
       ]
     dir: "."
   # Push the container image to Artifact Registry
   - name: "gcr.io/cloud-builders/docker"
-    args: ["push", "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${_IMAGE_TAG}"]
+    args: ["push", "${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_REGISTRY}/${_IMAGE_NAME}:${_IMAGE_TAG}"]
 images:
-  - ${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_NAME}:${_IMAGE_TAG}
+  - ${_GCR_LOCATION}/$PROJECT_ID/${_IMAGE_REGISTRY}/${_IMAGE_NAME}:${_IMAGE_TAG}
 options:
   requestedVerifyOption: VERIFIED
   machineType: E2_HIGHCPU_32


### PR DESCRIPTION
## Add :latest tag when creating workstation configuration

When I tried creating the workstations without specifying a tag to pull,
they failed to pull every time. Maybe Cloud Workstations doesn't
automatically default to `:latest` when no tag is specified?

Curious if this was working for you @kmontg @jerop as it was - maybe there was something else going wrong 🤷‍♀️ 🤷‍♀️ 🤷‍♀️ 

## Make instructions for providing your own image registry a bit clearer

I tried to run through this myself and got a bit confused so I added
another substitution var for the image registry, and changed the example
GCB command to provide the substitutions on the command line so you
don't need to change the cloudbuild.yaml to change those values.

Re-added logic I'd (foolishly) previousy removed to default the tag to
'latest' if no commit hash env var exists.

Also changed markdown numbering so that items can be moved around/added
without having to keep them all in sync.

## Move local instructions to the bottom
Assuming most ppl will come to this repo wanting to run this as a
cloud workstation, so putting those instructions first in the README.
