### PR TITLE
Few tweaks in cache paths

### DIFF
--- a/llm-tool/modeldownload.py
+++ b/llm-tool/modeldownload.py
@@ -64,7 +64,10 @@ def remove(repo_id, filename):
     if filename:
         path = modelfiles.path_from_model(repo_files, filename)
         if path:
+            blob_path = os.path.realpath(path)
             os.remove(path)
+        if os.path.isfile(blob_path):
+            os.remove(blob_path)
     if not filename:
         path = modelfiles.path_from_repo(repo_id)
         if path:

--- a/llm-tool/modelfiles.py
+++ b/llm-tool/modelfiles.py
@@ -18,13 +18,14 @@
 """
 import os
 
+from huggingface_hub import constants
 
-MODEL_DIR = "~/.cache/huggingface/hub/"
+
 DEFAULT_FILE_EXT = "gguf"
 
 
 def get_model_dir():
-    return os.path.expanduser(MODEL_DIR)
+    return constants.HF_HUB_CACHE
 
 
 def list_models():


### PR DESCRIPTION
Hi there! I'm Wauplin, working at HF as `huggingface_hub` maintainer :hugs: . Very cool project! :fire:

I quickly reviewed the integration with `huggingface_hub` which looks quite well managed already. I opened this PR to update two things:
- it's preferred to use `huggingface_hub.constants.HF_HUB_CACHE` rather than hard-coding `"~/.cache/huggingface/hub/"`. First, it will make the project compatible with Windows machine. And moreover it will respect the `HF_HOME` / `HF_HUB_CACHE` environment variables if the user chose to locate their files in a different volume. More details about environment variables [here](https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables).
- when deleting a single file from the cache, you should also remove the associated blob file. Here is [a guide](https://huggingface.co/docs/huggingface_hub/guides/manage-cache) on how cache is working in the HF ecosystem. In the current implementation, doing `os.remove(".../.../...gguf")` is not enough since it would only remove the symlink and not the underlying file (i.e. the "real huge file"). Note that deleting the blob file might break the cache if several revisions of the same repo where downloaded but I don't think it's really relevant in the context here. In general, cache management can be tricky so `huggingface-cli delete-cache` is the preferred to handle cache properly but I understand the need for a simple API here.



Also a remark about a comment in the code:

> Naming doesn't seem to be consistent across 🤗 but it does seem
    to be consistent across TheBloke's repos, so making some assumptions.

This is definitely true! The Hugging Face Hub is a platform that allow anyone to share their ML artifacts (models, datasets and demos). Artifacts are stored as git repositories in which we don't enforce any structure, given how diverse the ML ecosystem is. It is at the users and libraries discretion to know which models are compatible or not. We still try our best to provide guidelines and curate models metadata (to help with discoverability). So yes, TheBloke's repos are a great starting point for consistency! :smile: 