### PR TITLE
Stop llama-cpp-python from writing to broken pipe

### DIFF
--- a/llm-tool/modelserving.py
+++ b/llm-tool/modelserving.py
@@ -32,7 +32,8 @@ LOG_COMMAND="--log-config={}"
 
 def running_models():
     """
-    Returns a list of models that appear to be currently running
+    Returns a list of currently running models. Processes are assumed to be
+    running models if they have `RUN_BY_LOCALLM` environment variable set.
     """
     models = []
     for p in psutil.process_iter([]):
@@ -54,7 +55,7 @@ def start(path, host, port, log_config, verbose):
     log_config.
     """
     command = shlex.split(COMMAND.format(host, port))
-    if log_config != "":
+    if log_config:
         command.append(LOG_COMMAND.format(log_config))
     env = os.environ.copy()
 

--- a/llm-tool/modelserving.py
+++ b/llm-tool/modelserving.py
@@ -60,8 +60,12 @@ def start(path, host, port, log_config, verbose):
 
     # indicate that we started this process so we can easily find it later
     env["RUN_BY_LOCALLLM"] = "1"
-    # provide the model to run as an env variable
+    # provide the model to run to llama-cpp-python
     env["MODEL"] = os.path.expanduser(path)
+    # stop llama-cpp-python from writing to stderr. we pipe stderr to this
+    # process, but then we close the pipe, so subsequent writes to stderr
+    # directly fail, causing requests to throw exceptions
+    env["VERBOSE"] = "False"
 
     p = subprocess.Popen(
         command,


### PR DESCRIPTION
llama-cpp-python has a flag 'verbose' which defaults to true and when
set causes it to write things to stderr. It doesn't include anyway to
configure where these logs are directed, so it's stderr or nothing.

Unfortunately the when we start the process running llama-cpp-python, we
provide a pipe for stderr and then promptly close it. This means if
llama-cpp-python tries to write to stderr, a broken pipe exception is
thrown, which for example happens if there is a prefix cache hit when
processing a prompt
(https://github.com/abetlen/llama-cpp-python/blob/ae71ad1a147b10c2c3ba99eb086521cddcc4fad4/llama_cpp/llama.py#L645)
which likely explains why ppl are seeing 500s on the second time that
they try to run the same prompt. There are other situations that can
make llama-cpp-python try to write to stderr as well, which may also
cause 500s

The real fix here is to a) not provide a broken pipe for stderr and
b) for llama-cpp-python to allow us to configure logs (https://github.com/GoogleCloudPlatform/localllm/pull/18). For now
we can disable verbose mode in llama-cpp-python since we're not making
those logs available anyway and it should stop the 500s.

Fixes https://github.com/GoogleCloudPlatform/localllm/issues/7

(This branch depends on #18 so thats why you'll see those changes here as well)