### PR TITLE
Make it clear how long cluster creation takes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ To get started, you'll need to have a [GCP Project][gcp] and have the `gcloud` C
     ```
 
 1. Configure a Cloud Workstation cluster.
+
+   **Wait for this to complete before moving forward** which can take
+   [up to 20 minutes](https://cloud.google.com/workstations/docs/create-cluster#workstation-cluster).
     ```shell
     gcloud workstations clusters create $LOCALLLM_CLUSTER \
       --region=$REGION


### PR DESCRIPTION
As well as that it blocks subsequent steps.

I checked the docs to see if there are any similar warnings for workstation configuration or workstation creation, but there wasn't (except for more references to cluster creation taking up to 20 min).

Fixes #12