### PR TITLE
Recommend `gcloud beta workstations` until flag issue fix rolls out

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To get started, you'll need to have a [GCP Project][gcp] and have the `gcloud` C
 1. Create a Cloud Workstation configuration. We suggest using a machine type of e2-standard-32 which has 32 vCPU, 16
    core and 128 GB memory.
     ```shell
-    gcloud workstations configs create $LOCALLLM_WORKSTATION \
+    gcloud beta workstations configs create $LOCALLLM_WORKSTATION \
     --region=$REGION \
     --cluster=$LOCALLLM_CLUSTER \
     --machine-type=e2-standard-32 \


### PR DESCRIPTION
In #23 @pythongiant pointed out that gcloud is erroring out on workstation config creation. After digging into it a bit more this is a bug in the gcloud command, and it looks like a fix is coming out with the next version, but for now we can work around it by using `gcloud beta` (I believe the issue is that the flag is trying to do something that isn't actually (yet?) supported in the GA track, so it shouldn't have been exposed there, but unfortunately both is and is on by default - though I believe w/ value false)